### PR TITLE
Assert macro with errno decoding

### DIFF
--- a/pc/headers.h
+++ b/pc/headers.h
@@ -32,4 +32,6 @@
 	#define min _MIN
 #endif
 
+#define ASSERT_NO_ERROR(result) if(result < 0) { fprintf(stderr, "%s:%i: Fatal error in last operation: %s\n", __FILE__, __LINE__, strerror(errno)); assert(result >= 0); }
+
 #endif	// WIN_HEADERS_H

--- a/pc/sio.cpp
+++ b/pc/sio.cpp
@@ -108,6 +108,7 @@ SIO::Result SIO::Open(const std::string& serialDevice, int baud)
 	timeouts = 2000;
 
 	hSerialPort = open(serialDevice.c_str(), O_RDWR | O_NDELAY);
+	ASSERT_NO_ERROR(hSerialPort);
 	/*
 	hfile = CreateFile(	buf,
 				GENERIC_READ | GENERIC_WRITE,
@@ -126,13 +127,15 @@ SIO::Result SIO::Open(const std::string& serialDevice, int baud)
 	//dcb.DCBlength = sizeof(DCB);
 	//GetCommState(hfile, &dcb); < tcgetattr
 	// Get the current serial port status, try to set baud, and reset attr
-	assert(tcgetattr(hSerialPort, &dcb.config) >= 0);
+	int result = tcgetattr(hSerialPort, &dcb.config);
+	ASSERT_NO_ERROR(result);
 	if (!SetMode(baud))
 	{
 		Close();
 		return ERRCONFIG;
 	}
-	assert(tcflush(hSerialPort, TCIFLUSH) >= 0);
+	result = tcflush(hSerialPort, TCIFLUSH) >= 0;
+	ASSERT_NO_ERROR(result);
 	//PurgeComm(hfile, 
 	//	PURGE_TXABORT| // terminate write 
 	//	PURGE_TXCLEAR| // clear output buffer

--- a/pc/sio.cpp
+++ b/pc/sio.cpp
@@ -126,13 +126,13 @@ SIO::Result SIO::Open(const std::string& serialDevice, int baud)
 	//dcb.DCBlength = sizeof(DCB);
 	//GetCommState(hfile, &dcb); < tcgetattr
 	// Get the current serial port status, try to set baud, and reset attr
-	tcgetattr(hSerialPort, &dcb.config);
+	assert(tcgetattr(hSerialPort, &dcb.config) >= 0);
 	if (!SetMode(baud))
 	{
 		Close();
 		return ERRCONFIG;
 	}
-	tcflush(hSerialPort, TCIFLUSH);
+	assert(tcflush(hSerialPort, TCIFLUSH) >= 0);
 	//PurgeComm(hfile, 
 	//	PURGE_TXABORT| // terminate write 
 	//	PURGE_TXCLEAR| // clear output buffer
@@ -200,7 +200,7 @@ void SIO::DCBToNix()
 bool SIO::SetMode(int baud)
 {
 	//PurgeComm(hfile, PURGE_TXCLEAR|PURGE_RXABORT|PURGE_RXCLEAR);
-	tcflush(hSerialPort, TCIFLUSH);
+	assert(tcflush(hSerialPort, TCIFLUSH) >= 0);
 	/*
 	dcb.BaudRate		= baud;
 	dcb.fBinary		= TRUE;
@@ -226,7 +226,8 @@ bool SIO::SetMode(int baud)
 	dcb.BaudRate = baud;
 	DCBToNix();
 	int r = tcsetattr(hSerialPort, TCSANOW, &dcb.config);
-	fcntl(hSerialPort, F_SETFL, 0);
+	assert(fcntl(hSerialPort, F_SETFL, 0) >= 0);
+	assert(r >= 0);
 	// 0 is a pass..
 
 	if(r == 0) r = 1;
@@ -236,12 +237,12 @@ bool SIO::SetMode(int baud)
 
 void SIO::SetTimeouts(int rto)
 {
-	tcflush(hSerialPort, TCIFLUSH);
+	assert(tcflush(hSerialPort, TCIFLUSH) >= 0);
 	if(dcb.BaudRate == 9600)
 		dcb.config.c_cc[VTIME] = 3;
 	else 
 		dcb.config.c_cc[VTIME] = 2;
-	tcsetattr(hSerialPort, TCSANOW, &dcb.config);
+	assert(tcsetattr(hSerialPort, TCSANOW, &dcb.config) >= 0);
 
 	/*
 	COMMTIMEOUTS cto;


### PR DESCRIPTION
I was just doing some dumb asserts to make sure that the sio calls were succeeding, but not decoding the errno before. Here's some code that does the assert _and_ fetches and decodes the errno.

Example output:
```
% ./xdisk3 b -p/dev/ttyS0

TransDisk 3.07
Copyright (C) 2000 cisc.
Unix port (C) 2021 b.f. 

sio.cpp:111: Error in last operation: No such file or directory
Assertion failed: (hSerialPort >= 0), function Open, file sio.cpp, line 111.
zsh: abort      ./xdisk3 b -p/dev/ttyS0
```